### PR TITLE
Fix AIMLAPI provider

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -73,6 +73,7 @@ The open-source community has created the following providers:
 - [LangDB Provider](/providers/community-providers/langdb) (`@langdb/vercel-provider`)
 - [Dify Provider](/providers/community-providers/dify) (`dify-ai-provider`)
 - [Sarvam Provider](/providers/community-providers/sarvam) (`sarvam-ai-provider`)
+- [AIMLAPI Provider](/providers/community-providers/aimlapi) (`@ai-sdk/aimlapi`)
 
 ## Self-Hosted Models
 

--- a/content/providers/03-community-providers/98-aimlapi.mdx
+++ b/content/providers/03-community-providers/98-aimlapi.mdx
@@ -1,0 +1,40 @@
+---
+title: AIMLAPI
+description: Learn how to use the AIMLAPI provider for the AI SDK.
+---
+
+# AIMLAPI Provider
+
+The **[AIMLAPI provider](https://github.com/aimlapi/aimlapi-ai-provider)** allows using models via the AIMLAPI service.
+
+## Setup
+
+The AIMLAPI provider is available in the `@ai-sdk/aimlapi` module. You can install it with
+
+```bash
+npm i @ai-sdk/aimlapi
+```
+
+## Provider Instance
+
+You can import `aimlapi` from `@ai-sdk/aimlapi` to create a provider instance:
+
+```ts
+import { aimlapi } from '@ai-sdk/aimlapi';
+```
+
+## Example
+
+```ts
+import { aimlapi } from '@ai-sdk/aimlapi';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: aimlapi('gpt-3.5-turbo'),
+  prompt: 'Hello from AIMLAPI!',
+});
+```
+
+## Documentation
+
+Please check out the **[AIMLAPI provider documentation](https://github.com/aimlapi/aimlapi-ai-provider)** for more information.

--- a/packages/aimlapi/CHANGELOG.md
+++ b/packages/aimlapi/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ai-sdk/aimlapi
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release of the AIMLAPI provider.

--- a/packages/aimlapi/src/aimlapi-image-model.test.ts
+++ b/packages/aimlapi/src/aimlapi-image-model.test.ts
@@ -1,0 +1,206 @@
+import { FetchFunction } from '@ai-sdk/provider-utils';
+import { createTestServer } from '@ai-sdk/provider-utils/test';
+import { describe, expect, it } from 'vitest';
+import { AimlapiImageModel } from './aimlapi-image-model';
+import { AimlapiImageSettings } from './aimlapi-image-settings';
+
+const prompt = 'A cute baby sea otter';
+
+function createBasicModel({
+  headers,
+  fetch,
+  currentDate,
+  settings,
+}: {
+  headers?: () => Record<string, string>;
+  fetch?: FetchFunction;
+  currentDate?: () => Date;
+  settings?: AimlapiImageSettings;
+} = {}) {
+  return new AimlapiImageModel(
+    'dall-e-2',
+    settings ?? {},
+    {
+      provider: 'aimlapi',
+      baseURL: 'https://api.example.com',
+      headers: headers ?? (() => ({ 'api-key': 'test-key' })),
+      fetch,
+      _internal: {
+        currentDate,
+      },
+    },
+  );
+}
+
+const server = createTestServer({
+  'https://api.example.com/*': {
+    response: {
+      type: 'binary',
+      body: Buffer.from('test-binary-content'),
+    },
+  },
+});
+
+describe('AimlapiImageModel', () => {
+  it('should pass the correct parameters including aspect ratio and seed', async () => {
+    const model = createBasicModel();
+
+    await model.doGenerate({
+      prompt,
+      n: 1,
+      size: undefined,
+      aspectRatio: '16:9',
+      seed: 42,
+      providerOptions: { aimlapi: { additional_param: 'value' } },
+    });
+
+    expect(await server.calls[0].requestBody).toStrictEqual({
+      prompt,
+      aspect_ratio: '16:9',
+      seed: 42,
+      additional_param: 'value',
+    });
+  });
+
+  it('should call the correct url', async () => {
+    const model = createBasicModel();
+
+    await model.doGenerate({
+      prompt,
+      n: 1,
+      size: undefined,
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {},
+    });
+
+    expect(server.calls[0].requestMethod).toStrictEqual('POST');
+    expect(server.calls[0].requestUrl).toStrictEqual(
+      'https://api.example.com/images/generations',
+    );
+  });
+
+  it('should pass headers', async () => {
+    const modelWithHeaders = createBasicModel({
+      headers: () => ({
+        'Custom-Provider-Header': 'provider-header-value',
+      }),
+    });
+
+    await modelWithHeaders.doGenerate({
+      prompt,
+      n: 1,
+      size: undefined,
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {},
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
+    });
+
+    expect(server.calls[0].requestHeaders).toStrictEqual({
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+    });
+  });
+
+  it('should handle API errors', async () => {
+    server.urls['https://api.example.com/*'].response = {
+      type: 'error',
+      status: 400,
+      body: 'Bad Request',
+    };
+
+    const model = createBasicModel();
+    await expect(
+      model.doGenerate({
+        prompt,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      }),
+    ).rejects.toMatchObject({
+      message: 'Bad Request',
+      statusCode: 400,
+      url: 'https://api.example.com/images/generations',
+      requestBodyValues: {
+        prompt,
+      },
+      responseBody: 'Bad Request',
+    });
+  });
+
+  it('should respect the abort signal', async () => {
+    const model = createBasicModel();
+    const controller = new AbortController();
+
+    const generatePromise = model.doGenerate({
+      prompt,
+      n: 1,
+      size: undefined,
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {},
+      abortSignal: controller.signal,
+    });
+
+    controller.abort();
+
+    await expect(generatePromise).rejects.toThrow('This operation was aborted');
+  });
+
+  describe('response metadata', () => {
+    it('should include timestamp, headers and modelId in response', async () => {
+      const testDate = new Date('2024-01-01T00:00:00Z');
+      const model = createBasicModel({
+        currentDate: () => testDate,
+      });
+
+      const result = await model.doGenerate({
+        prompt,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.response).toStrictEqual({
+        timestamp: testDate,
+        modelId: 'dall-e-2',
+        headers: expect.any(Object),
+      });
+    });
+
+    it('should include response headers from API call', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'binary',
+        body: Buffer.from('test-binary-content'),
+        headers: {
+          'x-request-id': 'test-request-id',
+          'content-type': 'image/png',
+        },
+      };
+
+      const model = createBasicModel();
+      const result = await model.doGenerate({
+        prompt,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.response.headers).toStrictEqual({
+        'content-length': '19',
+        'x-request-id': 'test-request-id',
+        'content-type': 'image/png',
+      });
+    });
+  });
+});

--- a/packages/aimlapi/src/aimlapi-image-model.ts
+++ b/packages/aimlapi/src/aimlapi-image-model.ts
@@ -113,7 +113,7 @@ export class AimlapiImageModel implements ImageModelV1 {
         aspect_ratio: aspectRatio,
         seed,
         ...(splitSize && { width: splitSize[0], height: splitSize[1] }),
-        ...(providerOptions.fireworks ?? {}),
+        ...(providerOptions.aimlapi ?? {}),
       },
       failedResponseHandler: createStatusCodeErrorResponseHandler(),
       successfulResponseHandler: createBinaryResponseHandler(),

--- a/packages/aimlapi/src/aimlapi-provider.test.ts
+++ b/packages/aimlapi/src/aimlapi-provider.test.ts
@@ -1,0 +1,135 @@
+import {
+  OpenAICompatibleChatLanguageModel,
+  OpenAICompatibleCompletionLanguageModel,
+  OpenAICompatibleEmbeddingModel,
+} from '@ai-sdk/openai-compatible';
+import { LanguageModelV1, EmbeddingModelV1 } from '@ai-sdk/provider';
+import { loadApiKey } from '@ai-sdk/provider-utils';
+import { AimlapiImageModel } from './aimlapi-image-model';
+import { createAIMLAPI } from './aimlapi-provider';
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+
+const OpenAICompatibleChatLanguageModelMock =
+  OpenAICompatibleChatLanguageModel as unknown as Mock;
+
+vi.mock('@ai-sdk/openai-compatible', () => ({
+  OpenAICompatibleChatLanguageModel: vi.fn(),
+  OpenAICompatibleCompletionLanguageModel: vi.fn(),
+  OpenAICompatibleEmbeddingModel: vi.fn(),
+}));
+
+vi.mock('@ai-sdk/provider-utils', () => ({
+  loadApiKey: vi.fn().mockReturnValue('mock-api-key'),
+  withoutTrailingSlash: vi.fn(url => url),
+}));
+
+vi.mock('./aimlapi-image-model', () => ({
+  AimlapiImageModel: vi.fn(),
+}));
+
+describe('AIMLAPIProvider', () => {
+  let mockLanguageModel: LanguageModelV1;
+  let mockEmbeddingModel: EmbeddingModelV1<string>;
+
+  beforeEach(() => {
+    mockLanguageModel = {} as LanguageModelV1;
+    mockEmbeddingModel = {} as EmbeddingModelV1<string>;
+    vi.clearAllMocks();
+  });
+
+  describe('createAIMLAPI', () => {
+    it('should create an AIMLAPIProvider instance with default options', () => {
+      const provider = createAIMLAPI();
+      const model = provider('model-id');
+      const constructorCall = OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[2];
+      config.headers();
+      expect(loadApiKey).toHaveBeenCalledWith({
+        apiKey: undefined,
+        environmentVariableName: 'AIMLAPI_API_KEY',
+        description: 'AIMLAPI API key',
+      });
+    });
+
+    it('should create an AIMLAPIProvider instance with custom options', () => {
+      const options = {
+        apiKey: 'custom-key',
+        baseURL: 'https://custom.url',
+        headers: { 'Custom-Header': 'value' },
+      };
+      const provider = createAIMLAPI(options);
+      const model = provider('model-id');
+      const constructorCall = OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[2];
+      config.headers();
+      expect(loadApiKey).toHaveBeenCalledWith({
+        apiKey: 'custom-key',
+        environmentVariableName: 'AIMLAPI_API_KEY',
+        description: 'AIMLAPI API key',
+      });
+    });
+
+    it('should return a chat model when called as a function', () => {
+      const provider = createAIMLAPI();
+      const model = provider('foo-model-id', { user: 'foo-user' });
+      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+    });
+  });
+
+  describe('chatModel', () => {
+    it('should construct a chat model with correct configuration', () => {
+      const provider = createAIMLAPI();
+      const model = provider.chatModel('aimlapi-chat-model', { user: 'foo-user' });
+      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+    });
+  });
+
+  describe('completionModel', () => {
+    it('should construct a completion model with correct configuration', () => {
+      const provider = createAIMLAPI();
+      const model = provider.completionModel('aimlapi-completion-model', {
+        user: 'foo-user',
+      });
+      expect(model).toBeInstanceOf(OpenAICompatibleCompletionLanguageModel);
+    });
+  });
+
+  describe('textEmbeddingModel', () => {
+    it('should construct a text embedding model with correct configuration', () => {
+      const provider = createAIMLAPI();
+      const model = provider.textEmbeddingModel('aimlapi-embedding-model', {
+        user: 'foo-user',
+      });
+      expect(model).toBeInstanceOf(OpenAICompatibleEmbeddingModel);
+    });
+  });
+
+  describe('imageModel', () => {
+    it('should construct an image model with correct configuration', () => {
+      const provider = createAIMLAPI();
+      const modelId = 'dall-e-2';
+      const settings = { maxImagesPerCall: 2 };
+      const model = provider.imageModel!(modelId as any, settings);
+      expect(AimlapiImageModel).toHaveBeenCalledWith(
+        modelId,
+        settings,
+        expect.objectContaining({
+          provider: 'aimlapi.image',
+          baseURL: 'https://api.aimlapi.com/v1',
+        }),
+      );
+      expect(model).toBeInstanceOf(AimlapiImageModel);
+    });
+
+    it('should pass custom baseURL to image model', () => {
+      const provider = createAIMLAPI({ baseURL: 'https://custom.url/' });
+      const modelId = 'dall-e-2';
+      provider.imageModel!(modelId as any);
+      expect(AimlapiImageModel).toHaveBeenCalledWith(
+        modelId,
+        expect.any(Object),
+        expect.objectContaining({ baseURL: 'https://custom.url/' }),
+      );
+    });
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -43,7 +43,8 @@
         "TOGETHER_AI_API_KEY",
         "VERCEL_API_KEY",
         "VERCEL_URL",
-        "XAI_API_KEY"
+        "XAI_API_KEY",
+        "AIMLAPI_API_KEY"
       ],
       "outputs": [
         "dist/**",


### PR DESCRIPTION
## Summary
- add AIMLAPI provider docs and changelog
- add provider tests and image model tests
- fix providerOptions reference
- add AIMLAPI_API_KEY to turbo.json
- link AIMLAPI provider in docs

## Testing
- `pnpm --filter @ai-sdk/aimlapi test:node` *(fails: Failed to load url @ai-sdk/provider-utils/test)*

------
https://chatgpt.com/codex/tasks/task_e_68418ce390cc8329b9c309315deb9a62